### PR TITLE
chore: Enable dual-direction markets with directional market IDs

### DIFF
--- a/examples/gno.land/p/volos/consts/consts.gno
+++ b/examples/gno.land/p/volos/consts/consts.gno
@@ -1,4 +1,4 @@
-package volos
+package consts
 
 import (
 	u256 "gno.land/p/gnoswap/uint256"

--- a/examples/gno.land/p/volos/consts/gnomod.toml
+++ b/examples/gno.land/p/volos/consts/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/volos/consts"
+gno = "0.9"

--- a/examples/gno.land/p/volos/math/gnomod.toml
+++ b/examples/gno.land/p/volos/math/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/volos/math"
+gno = "0.9"

--- a/examples/gno.land/p/volos/math/math.gno
+++ b/examples/gno.land/p/volos/math/math.gno
@@ -1,27 +1,28 @@
-package volos
+package math
 
 import (
 	"gno.land/p/gnoswap/uint256"
+	"gno.land/p/volos/consts"
 )
 
 // WMulDown returns (x * y) / WAD rounded down
 func WMulDown(x, y *uint256.Uint) *uint256.Uint {
-	return uint256.MulDiv(x, y, WAD)
+	return uint256.MulDiv(x, y, consts.WAD)
 }
 
 // WMulUp returns (x * y) / WAD rounded up
 func WMulUp(x, y *uint256.Uint) *uint256.Uint {
-	return uint256.MulDivRoundingUp(x, y, WAD)
+	return uint256.MulDivRoundingUp(x, y, consts.WAD)
 }
 
 // WDivDown returns (x * WAD) / y rounded down
 func WDivDown(x, y *uint256.Uint) *uint256.Uint {
-	return uint256.MulDiv(x, WAD, y)
+	return uint256.MulDiv(x, consts.WAD, y)
 }
 
 // WDivUp returns (x * WAD) / y rounded up
 func WDivUp(x, y *uint256.Uint) *uint256.Uint {
-	return uint256.MulDivRoundingUp(x, WAD, y)
+	return uint256.MulDivRoundingUp(x, consts.WAD, y)
 }
 
 // MulDivDown multiplies two numbers and divides by a third, rounding down.
@@ -43,11 +44,11 @@ func WTaylorCompounded(x, n *uint256.Uint) *uint256.Uint {
 	firstTerm := new(uint256.Uint).Mul(x, n)
 
 	// Second term: (firstTerm * firstTerm) / (2 * WAD)
-	twoWad := new(uint256.Uint).Mul(uint256.NewUint(2), WAD)
+	twoWad := new(uint256.Uint).Mul(uint256.NewUint(2), consts.WAD)
 	secondTerm := MulDivDown(firstTerm, firstTerm, twoWad)
 
 	// Third term: (secondTerm * firstTerm) / (3 * WAD)
-	threeWad := new(uint256.Uint).Mul(uint256.NewUint(3), WAD)
+	threeWad := new(uint256.Uint).Mul(uint256.NewUint(3), consts.WAD)
 	thirdTerm := MulDivDown(secondTerm, firstTerm, threeWad)
 
 	// Sum all terms

--- a/examples/gno.land/p/volos/math/shares_math.gno
+++ b/examples/gno.land/p/volos/math/shares_math.gno
@@ -1,4 +1,4 @@
-package volos
+package math
 
 import (
 	u256 "gno.land/p/gnoswap/uint256"

--- a/examples/gno.land/r/volos/core/api.gno
+++ b/examples/gno.land/r/volos/core/api.gno
@@ -1,4 +1,4 @@
-package volos
+package core
 
 import (
 	"gno.land/p/demo/json"

--- a/examples/gno.land/r/volos/core/errors.gno
+++ b/examples/gno.land/r/volos/core/errors.gno
@@ -1,4 +1,4 @@
-package volos
+package core
 
 import (
 	"errors"

--- a/examples/gno.land/r/volos/core/events.gno
+++ b/examples/gno.land/r/volos/core/events.gno
@@ -1,4 +1,4 @@
-package volos
+package core
 
 import (
 	"std"

--- a/examples/gno.land/r/volos/core/getter.gno
+++ b/examples/gno.land/r/volos/core/getter.gno
@@ -1,4 +1,4 @@
-package volos
+package core
 
 import (
 	"std"

--- a/examples/gno.land/r/volos/core/json.gno
+++ b/examples/gno.land/r/volos/core/json.gno
@@ -1,8 +1,9 @@
-package volos
+package core
 
 import (
 	"gno.land/p/demo/json"
 	u256 "gno.land/p/gnoswap/uint256"
+	"gno.land/p/volos/math"
 )
 
 // RpcMarket
@@ -164,7 +165,7 @@ func GetRpcMarketInfo(marketId string) RpcMarketInfo {
 	if market.TotalSupplyAssets.IsZero() {
 		utilization = u256.Zero()
 	} else {
-		utilization = WDivDown(market.TotalBorrowAssets, market.TotalSupplyAssets)
+		utilization = math.WDivDown(market.TotalBorrowAssets, market.TotalSupplyAssets)
 	}
 
 	// Get token paths

--- a/examples/gno.land/r/volos/core/oracle.gno
+++ b/examples/gno.land/r/volos/core/oracle.gno
@@ -9,12 +9,12 @@ import (
 
 // GetPrice returns the price from a Gnoswap pool
 // The price is returned as a sqrtPriceX96e36 (36 decimals) in terms of loan token per collateral token
-func GetPrice(poolPath string) *u256.Uint {
+func GetPrice(marketId string) *u256.Uint {
 	// Get market params to determine token ordering
-	_, params := GetMarket(poolPath)
+	_, params := GetMarket(marketId)
 
 	// Get the sqrt price from the pool
-	sqrtPriceX96Str := pool.PoolGetSlot0SqrtPriceX96(poolPath)
+	sqrtPriceX96Str := pool.PoolGetSlot0SqrtPriceX96(params.PoolPath)
 	if sqrtPriceX96Str == "" {
 		panic(ErrPriceNotAvailable)
 	}

--- a/examples/gno.land/r/volos/core/oracle.gno
+++ b/examples/gno.land/r/volos/core/oracle.gno
@@ -1,8 +1,10 @@
-package volos
+package core
 
 import (
 	u256 "gno.land/p/gnoswap/uint256"
 	"gno.land/r/gnoswap/v1/pool"
+	"gno.land/p/volos/consts"
+	"gno.land/p/volos/math"
 )
 
 // GetPrice returns the price from a Gnoswap pool
@@ -24,13 +26,13 @@ func GetPrice(poolPath string) *u256.Uint {
 	priceQ192 := new(u256.Uint).Mul(sqrtPriceX96, sqrtPriceX96)
 
 	// Finally divide by Q192 to get the actual price ratio with ORACLE_PRICE_SCALE precision
-	price := MulDivDown(priceQ192, ORACLE_PRICE_SCALE, Q192)
+	price := math.MulDivDown(priceQ192, consts.ORACLE_PRICE_SCALE, consts.Q192)
 
 	// If token0 is the loan token, we need to invert the price
 	// because Gnoswap's price is always token1/token0
 	if params.IsToken0Loan {
 		// Invert price: ORACLE_PRICE_SCALE² / price
-		price = MulDivDown(ORACLE_PRICE_SCALE, ORACLE_PRICE_SCALE, price)
+		price = math.MulDivDown(consts.ORACLE_PRICE_SCALE, consts.ORACLE_PRICE_SCALE, price)
 	}
 
 	return price

--- a/examples/gno.land/r/volos/core/periphery.gno
+++ b/examples/gno.land/r/volos/core/periphery.gno
@@ -1,8 +1,10 @@
-package volos
+package core
 
 import (
 	"gno.land/p/demo/avl"
 	u256 "gno.land/p/gnoswap/uint256"
+	"gno.land/p/volos/consts"
+	"gno.land/p/volos/math"
 )
 
 // ExpectedMarketBalances returns the expected market balances after interest accrual
@@ -52,7 +54,7 @@ func ExpectedSupplyAssets(marketId string, user string) *u256.Uint {
 	position := GetPosition(marketId, user)
 	market, _ := GetMarket(marketId)
 
-	return ToAssetsDown(position.SupplyShares, market.TotalSupplyAssets, market.TotalSupplyShares)
+	return math.ToAssetsDown(position.SupplyShares, market.TotalSupplyAssets, market.TotalSupplyShares)
 }
 
 // ExpectedBorrowAssets returns the expected borrow assets balance of a user after interest accrual
@@ -65,7 +67,7 @@ func ExpectedBorrowAssets(marketId string, user string) *u256.Uint {
 	position := GetPosition(marketId, user)
 	market, _ := GetMarket(marketId)
 
-	return ToAssetsUp(position.BorrowShares, market.TotalBorrowAssets, market.TotalBorrowShares)
+	return math.ToAssetsUp(position.BorrowShares, market.TotalBorrowAssets, market.TotalBorrowShares)
 }
 
 // CalculateBorrowRate returns the current borrow rate per second
@@ -108,16 +110,16 @@ func CalculateSupplyRate(marketId string) *u256.Uint {
 	borrowRate := irm.BorrowRate(market.TotalSupplyAssets, market.TotalBorrowAssets)
 
 	// Calculate utilization rate: totalBorrow / totalSupply
-	utilizationRate := WDivDown(market.TotalBorrowAssets, market.TotalSupplyAssets)
+	utilizationRate := math.WDivDown(market.TotalBorrowAssets, market.TotalSupplyAssets)
 
 	// Calculate fee-adjusted borrow rate
-	feeFactor := new(u256.Uint).Sub(WAD, market.Fee) // (1 - fee)
+	feeFactor := new(u256.Uint).Sub(consts.WAD, market.Fee) // (1 - fee)
 
 	// Supply rate = borrow rate * utilization rate * (1 - fee)
 	// This formula accounts for:
 	// 1. Interest is only earned on the portion of funds being borrowed (utilization)
 	// 2. A portion of interest (the fee) goes to the fee recipient
-	return WMulDown(WMulDown(borrowRate, utilizationRate), feeFactor)
+	return math.WMulDown(math.WMulDown(borrowRate, utilizationRate), feeFactor)
 }
 
 // CalculateBorrowAPR returns the current borrow APR (scaled by WAD)
@@ -159,7 +161,7 @@ func CalculateLoanAmount(marketId string, user string) *u256.Uint {
 	market, _ := GetMarket(marketId)
 
 	// Calculate current borrowed value using ToAssetsUp for safety
-	return ToAssetsUp(
+	return math.ToAssetsUp(
 		position.BorrowShares,
 		market.TotalBorrowAssets,
 		market.TotalBorrowShares,
@@ -212,13 +214,13 @@ func CalculateHealthFactor(marketId string, userAddr string) *u256.Uint {
 
 	// If no borrows, position is maximally healthy (return a very large number)
 	if position.BorrowShares.IsZero() {
-		return new(u256.Uint).Mul(WAD, u256.NewUint(100)) // 100 * WAD
+		return new(u256.Uint).Mul(consts.WAD, u256.NewUint(100)) // 100 * WAD
 	}
 
 	market, params := GetMarket(marketId)
 
 	// Calculate current borrowed value
-	borrowed := ToAssetsUp(
+	borrowed := math.ToAssetsUp(
 		position.BorrowShares,
 		market.TotalBorrowAssets,
 		market.TotalBorrowShares,
@@ -232,12 +234,12 @@ func CalculateHealthFactor(marketId string, userAddr string) *u256.Uint {
 	collateralPrice := GetPrice(params.PoolPath)
 
 	// Calculate max borrow allowed
-	maxBorrow := WMulDown(MulDivDown(position.Collateral, collateralPrice, ORACLE_PRICE_SCALE), params.LLTV)
+	maxBorrow := math.WMulDown(math.MulDivDown(position.Collateral, collateralPrice, consts.ORACLE_PRICE_SCALE), params.LLTV)
 
 	// Health factor = maxBorrow / borrowed (WAD scaled)
 	if borrowed.IsZero() {
-		return new(u256.Uint).Mul(WAD, u256.NewUint(100)) // 100 * WAD
+		return new(u256.Uint).Mul(consts.WAD, u256.NewUint(100)) // 100 * WAD
 	}
 
-	return WDivDown(maxBorrow, borrowed)
+	return math.WDivDown(maxBorrow, borrowed)
 }

--- a/examples/gno.land/r/volos/core/periphery.gno
+++ b/examples/gno.land/r/volos/core/periphery.gno
@@ -231,7 +231,7 @@ func CalculateHealthFactor(marketId string, userAddr string) *u256.Uint {
 		return u256.Zero()
 	}
 
-	collateralPrice := GetPrice(params.PoolPath)
+	collateralPrice := GetPrice(marketId)
 
 	// Calculate max borrow allowed
 	maxBorrow := math.WMulDown(math.MulDivDown(position.Collateral, collateralPrice, consts.ORACLE_PRICE_SCALE), params.LLTV)

--- a/examples/gno.land/r/volos/core/types.gno
+++ b/examples/gno.land/r/volos/core/types.gno
@@ -27,7 +27,7 @@ type Position struct {
 type MarketParams struct {
 	PoolPath     string     // Gnoswap pool path (e.g. "token0:token1:3000") - also used as oracle
 	IRM          string     // Interest Rate Model path
-	LLTV         *u256.Uint // Liquidation Loan-to-Value ratio as a percentage
+	LLTV         *u256.Uint // Liquidation Loan-to-Value ratio (WAD-scaled, e.g., 75% = 0.75 * 1e18)
 	IsToken0Loan bool       // Whether token0 is the loan token (if false, token1 is the loan token)
 }
 
@@ -67,6 +67,6 @@ type IRM interface {
 // FlashLoanCallback interface that users willing to use flash loans must implement
 type FlashLoanCallback interface {
 	// OnVolosFlashLoan is called when a flash loan occurs
-	OnVolosFlashLoan(cur realm, assets int64, data []byte)
+	OnVolosFlashLoan(cur realm, assets int64, data any)
 }
 

--- a/examples/gno.land/r/volos/core/types.gno
+++ b/examples/gno.land/r/volos/core/types.gno
@@ -27,13 +27,16 @@ type Position struct {
 type MarketParams struct {
 	PoolPath     string     // Gnoswap pool path (e.g. "token0:token1:3000") - also used as oracle
 	IRM          string     // Interest Rate Model path
-	LLTV         *u256.Uint // Liquidation Loan-to-Value ratio as a percentage (e.g. 75 means 75%)
+	LLTV         *u256.Uint // Liquidation Loan-to-Value ratio as a percentage
 	IsToken0Loan bool       // Whether token0 is the loan token (if false, token1 is the loan token)
 }
 
 // ID generates a unique identifier for a market using the Gnoswap pool path
 func (mp *MarketParams) ID() string {
-	return mp.PoolPath
+	if mp.IsToken0Loan {
+		return mp.PoolPath + ":1"
+	}
+	return mp.PoolPath + ":0"
 }
 
 // GetLoanToken returns the loan token path from the pool path

--- a/examples/gno.land/r/volos/core/types.gno
+++ b/examples/gno.land/r/volos/core/types.gno
@@ -1,4 +1,4 @@
-package volos
+package core
 
 import (
 	u256 "gno.land/p/gnoswap/uint256"

--- a/examples/gno.land/r/volos/core/utils.gno
+++ b/examples/gno.land/r/volos/core/utils.gno
@@ -1,4 +1,4 @@
-package volos
+package core
 
 import (
 	"std"

--- a/examples/gno.land/r/volos/core/utils.gno
+++ b/examples/gno.land/r/volos/core/utils.gno
@@ -108,8 +108,6 @@ func safeTransferTo(tokenPath string, to std.Address, amount int64) {
 	}
 }
 
-
-
 // Helper function to check if two tokens exist together in a Gnoswap pool
 func areTokensPairedInGnoswap(token0, token1 string) bool {
 	poolPaths := pool.PoolGetPoolList()

--- a/examples/gno.land/r/volos/core/volos.gno
+++ b/examples/gno.land/r/volos/core/volos.gno
@@ -896,7 +896,7 @@ func isHealthy(marketId string, userAddr string) bool {
 /* FLASH LOANS */
 
 // FlashLoan allows users to borrow assets without collateral, provided they are repaid within the same transaction
-func FlashLoan(cur realm, token string, assets int64, data []byte, callback FlashLoanCallback) {
+func FlashLoan(cur realm, token string, assets int64, data any, callback FlashLoanCallback) {
 	if assets == 0 {
 		panic(ErrZeroAssets)
 	}

--- a/examples/gno.land/r/volos/core/volos.gno
+++ b/examples/gno.land/r/volos/core/volos.gno
@@ -1,4 +1,4 @@
-package volos
+package core
 
 import (
 	"std"
@@ -9,6 +9,8 @@ import (
 
 	u256 "gno.land/p/gnoswap/uint256"
 	pl "gno.land/r/gnoswap/v1/pool"
+	"gno.land/p/volos/consts"
+	"gno.land/p/volos/math"
 )
 
 /* STATE VARIABLES */
@@ -97,7 +99,7 @@ func EnableLLTV(cur realm, lltv int64) {
 
 	// Convert LLTV percentage to WAD-scaled value (e.g., 75% -> 0.75 * 1e18)
 	lltvUint := u256.NewUint(uint64(lltv))
-	lltvWad := MulDivDown(lltvUint, WAD, u256.NewUint(100)) // This will give us (lltv * 1e18) / 100
+	lltvWad := math.MulDivDown(lltvUint, consts.WAD, u256.NewUint(100)) // This will give us (lltv * 1e18) / 100
 
 	// Convert LLTV to string for use as key in tree
 	lltvStr := lltvWad.ToString()
@@ -132,7 +134,7 @@ func setFee(cur realm, marketId string, newFee *u256.Uint) {
 	}
 
 	// Check fee doesn't exceed maximum
-	if newFee.Cmp(MAX_FEE) > 0 {
+	if newFee.Cmp(consts.MAX_FEE) > 0 {
 		panic(ErrMaxFeeExceeded)
 	}
 
@@ -161,7 +163,7 @@ func CreateMarket(cur realm, poolPath string, isToken0Loan bool, irm string, llt
 
 	// Convert LLTV percentage to WAD-scaled value (e.g., 75% -> 0.75 * 1e18)
 	lltvUint := u256.NewUint(uint64(lltv))
-	lltvWad := MulDivDown(lltvUint, WAD, u256.NewUint(100)) // This will give us (lltv * 1e18) / 100
+	lltvWad := math.MulDivDown(lltvUint, consts.WAD, u256.NewUint(100)) // This will give us (lltv * 1e18) / 100
 
 	// Create market params
 	params := MarketParams{
@@ -247,14 +249,14 @@ func SupplyOnBehalf(cur realm, marketId string, assets, shares uint64, onBehalf 
 	// Calculate shares to mint
 	var sharesToMint *u256.Uint
 	if assets > 0 {
-		sharesToMint = ToSharesDown(
+		sharesToMint = math.ToSharesDown(
 			assetsU256,
 			market.TotalSupplyAssets,
 			market.TotalSupplyShares,
 		)
 	} else {
 		sharesToMint = sharesU256
-		assetsU256 = ToAssetsUp(
+		assetsU256 = math.ToAssetsUp(
 			sharesU256,
 			market.TotalSupplyAssets,
 			market.TotalSupplyShares,
@@ -322,14 +324,14 @@ func WithdrawOnBehalf(cur realm, marketId string, assets, shares uint64, onBehal
 	// Calculate shares to burn
 	var sharesToBurn *u256.Uint
 	if assets > 0 {
-		sharesToBurn = ToSharesUp(
+		sharesToBurn = math.ToSharesUp(
 			assetsU256,
 			market.TotalSupplyAssets,
 			market.TotalSupplyShares,
 		)
 	} else {
 		sharesToBurn = sharesU256
-		assetsU256 = ToAssetsDown(
+		assetsU256 = math.ToAssetsDown(
 			sharesU256,
 			market.TotalSupplyAssets,
 			market.TotalSupplyShares,
@@ -417,14 +419,14 @@ func BorrowOnBehalf(cur realm, marketId string, assets, shares uint64, onBehalf 
 	// Calculate shares to mint
 	var sharesToMint *u256.Uint
 	if assets > 0 {
-		sharesToMint = ToSharesUp(
+		sharesToMint = math.ToSharesUp(
 			assetsU256,
 			market.TotalBorrowAssets,
 			market.TotalBorrowShares,
 		)
 	} else {
 		sharesToMint = sharesU256
-		assetsU256 = ToAssetsDown(
+		assetsU256 = math.ToAssetsDown(
 			sharesU256,
 			market.TotalBorrowAssets,
 			market.TotalBorrowShares,
@@ -495,14 +497,14 @@ func RepayOnBehalf(cur realm, marketId string, assets, shares uint64, onBehalf s
 	// Calculate shares to burn
 	var sharesToBurn *u256.Uint
 	if assets > 0 {
-		sharesToBurn = ToSharesDown(
+		sharesToBurn = math.ToSharesDown(
 			assetsU256,
 			market.TotalBorrowAssets,
 			market.TotalBorrowShares,
 		)
 	} else {
 		sharesToBurn = sharesU256
-		assetsU256 = ToAssetsUp(
+		assetsU256 = math.ToAssetsUp(
 			sharesU256,
 			market.TotalBorrowAssets,
 			market.TotalBorrowShares,
@@ -663,39 +665,39 @@ func Liquidate(cur realm, marketId string, borrower std.Address, seizedAssets, r
 	}
 
 	// Calculate the liquidation incentive factor: min(maxLiquidationIncentiveFactor, 1/(1 - cursor*(1 - lltv)))
-	incentiveFactor := WDivDown(
-		WAD,
-		new(u256.Uint).Sub(WAD, WMulDown(LIQUIDATION_CURSOR, new(u256.Uint).Sub(WAD, params.LLTV))),
+	incentiveFactor := math.WDivDown(
+		consts.WAD,
+		new(u256.Uint).Sub(consts.WAD, math.WMulDown(consts.LIQUIDATION_CURSOR, new(u256.Uint).Sub(consts.WAD, params.LLTV))),
 	)
-	incentiveFactor = Min(incentiveFactor, MAX_LIQUIDATION_INCENTIVE_FACTOR)
+	incentiveFactor = Min(incentiveFactor, consts.MAX_LIQUIDATION_INCENTIVE_FACTOR)
 
 	// Calculate seized assets or repaid shares based on input
 	if seizedAssets > 0 {
 		// Calculate repaid shares from seized assets
-		seizedAssetsQuoted := MulDivUp(seizedAssetsU256, collateralPrice, ORACLE_PRICE_SCALE)
-		repaidSharesU256 = ToSharesUp(
-			WDivUp(seizedAssetsQuoted, incentiveFactor),
+		seizedAssetsQuoted := math.MulDivUp(seizedAssetsU256, collateralPrice, consts.ORACLE_PRICE_SCALE)
+		repaidSharesU256 = math.ToSharesUp(
+			math.WDivUp(seizedAssetsQuoted, incentiveFactor),
 			market.TotalBorrowAssets,
 			market.TotalBorrowShares,
 		)
 	} else {
 		// Calculate seized assets from repaid shares
-		seizedAssetsU256 = MulDivDown(
-			WMulDown(
-				ToAssetsDown(
+		seizedAssetsU256 = math.MulDivDown(
+			math.WMulDown(
+				math.ToAssetsDown(
 					repaidSharesU256,
 					market.TotalBorrowAssets,
 					market.TotalBorrowShares,
 				),
 				incentiveFactor,
 			),
-			ORACLE_PRICE_SCALE,
+			consts.ORACLE_PRICE_SCALE,
 			collateralPrice,
 		)
 	}
 
 	// Calculate repaid assets
-	repaidAssets := ToAssetsUp(
+	repaidAssets := math.ToAssetsUp(
 		repaidSharesU256,
 		market.TotalBorrowAssets,
 		market.TotalBorrowShares,
@@ -713,7 +715,7 @@ func Liquidate(cur realm, marketId string, borrower std.Address, seizedAssets, r
 	// Handle bad debt if all collateral is seized
 	if borrowerPos.Collateral.IsZero() {
 		badDebtShares := borrowerPos.BorrowShares
-		badDebtAssets := ToAssetsUp(
+		badDebtAssets := math.ToAssetsUp(
 			badDebtShares,
 			market.TotalBorrowAssets,
 			market.TotalBorrowShares,
@@ -824,9 +826,9 @@ func accrueInterest(marketId string) {
 	// wTaylorCompounded returns the sum of first 3 terms: x*n + (x*n)^2/2 + (x*n)^3/6
 	// This approximates continuous compound interest more accurately than simple interest
 	elapsedUint := u256.NewUint(uint64(elapsed))
-	wtc := WTaylorCompounded(borrowRate, elapsedUint)
+	wtc := math.WTaylorCompounded(borrowRate, elapsedUint)
 
-	interest := WMulDown(market.TotalBorrowAssets, wtc)
+	interest := math.WMulDown(market.TotalBorrowAssets, wtc)
 
 	// Update market state
 	market.TotalBorrowAssets = new(u256.Uint).Add(market.TotalBorrowAssets, interest)
@@ -835,12 +837,12 @@ func accrueInterest(marketId string) {
 	// Handle fees if any
 	if !market.Fee.IsZero() && feeRecipient != "" {
 		// Calculate fee amount
-		feeAmount := WMulDown(interest, market.Fee)
+		feeAmount := math.WMulDown(interest, market.Fee)
 
 		// Calculate fee shares
 		// The fee amount is subtracted from total supply to compensate for already increased supply
 		totalSupplyMinusFee := new(u256.Uint).Sub(market.TotalSupplyAssets, feeAmount)
-		feeShares := ToSharesDown(
+		feeShares := math.ToSharesDown(
 			feeAmount,
 			totalSupplyMinusFee,
 			market.TotalSupplyShares,
@@ -879,7 +881,7 @@ func isHealthy(marketId string, userAddr string) bool {
 	market, params := GetMarket(marketId)
 
 	// Calculate current borrowed value
-	borrowed := ToAssetsUp(
+	borrowed := math.ToAssetsUp(
 		position.BorrowShares,
 		market.TotalBorrowAssets,
 		market.TotalBorrowShares,
@@ -888,7 +890,7 @@ func isHealthy(marketId string, userAddr string) bool {
 	collateralPrice := GetPrice(params.PoolPath)
 
 	// Calculate max borrow allowed
-	maxBorrow := WMulDown(MulDivDown(position.Collateral, collateralPrice, ORACLE_PRICE_SCALE), params.LLTV)
+	maxBorrow := math.WMulDown(math.MulDivDown(position.Collateral, collateralPrice, consts.ORACLE_PRICE_SCALE), params.LLTV)
 
 	// Position is healthy if borrowed <= maxBorrow
 	return borrowed.Cmp(maxBorrow) <= 0

--- a/examples/gno.land/r/volos/core/volos.gno
+++ b/examples/gno.land/r/volos/core/volos.gno
@@ -887,7 +887,7 @@ func isHealthy(marketId string, userAddr string) bool {
 		market.TotalBorrowShares,
 	)
 
-	collateralPrice := GetPrice(params.PoolPath)
+	collateralPrice := GetPrice(marketId)
 
 	// Calculate max borrow allowed
 	maxBorrow := math.WMulDown(math.MulDivDown(position.Collateral, collateralPrice, consts.ORACLE_PRICE_SCALE), params.LLTV)

--- a/examples/gno.land/r/volos/mocks/flash_borrower.gno
+++ b/examples/gno.land/r/volos/mocks/flash_borrower.gno
@@ -16,7 +16,7 @@ var borrower *FlashBorrowerMock
 
 func init() {
 	borrower = &FlashBorrowerMock{
-		volosAddr: std.DerivePkgAddr("gno.land/r/volos"),
+		volosAddr: std.DerivePkgAddr("gno.land/r/volos/core"),
 	}
 }
 

--- a/examples/gno.land/r/volos/mocks/flash_borrower.gno
+++ b/examples/gno.land/r/volos/mocks/flash_borrower.gno
@@ -21,15 +21,15 @@ func init() {
 }
 
 // FlashLoan initiates a flash loan from Volos
-func FlashLoan(cur realm, token string, assets int64, data []byte) {
+func FlashLoan(cur realm, token string, assets int64, data any) {
 	// Call the Volos flash loan function with our borrower
 	volos.FlashLoan(cross, token, assets, data, borrower)
 }
 
 // OnVolosFlashLoan is the callback function that gets called during flash loan execution
 // This implements the FlashLoanCallback interface
-func (f *FlashBorrowerMock) OnVolosFlashLoan(cur realm, assets int64, data []byte) {
-	token := string(data)
+func (f *FlashBorrowerMock) OnVolosFlashLoan(cur realm, assets int64, data any) {
+	token := data.(string)
 
 	// Approve Volos to take back the tokens using the token's teller
 	tokenObj := grc20reg.MustGet(token)

--- a/examples/gno.land/r/volos/mocks/linear_irm.gno
+++ b/examples/gno.land/r/volos/mocks/linear_irm.gno
@@ -2,8 +2,9 @@ package mocks
 
 import (
 	volos "gno.land/r/volos/core"
-	u256 "gno.land/p/gnoswap/uint256"
 
+	u256 "gno.land/p/gnoswap/uint256"
+	"gno.land/p/volos/math"
 )
 
 // LinearIRM is a simple interest rate model where utilization rate directly corresponds to APR
@@ -24,7 +25,7 @@ func (irm *LinearIRM) BorrowRate(totalSupplyAssets, totalBorrowAssets *u256.Uint
 
 	// Calculate utilization rate scaled by WAD
 	// utilization = (totalBorrow * WAD) / totalSupply
-	utilization := volos.WDivDown(totalBorrowAssets, totalSupplyAssets)
+	utilization := math.WDivDown(totalBorrowAssets, totalSupplyAssets)
 
 	// Convert APR to per-second rate
 	// APR = utilization (e.g. 80% utilization = 80% APR)

--- a/volos-tests/flashloan.gno
+++ b/volos-tests/flashloan.gno
@@ -6,5 +6,5 @@ import (
 
 func main() {
 	// Test flash loan with GNS token
-	volos.FlashLoan(cross, "gno.land/r/gnoswap/v1/gns", 10000, []byte("gno.land/r/gnoswap/v1/gns"))
+	volos.FlashLoan(cross, "gno.land/r/gnoswap/v1/gns", 10000, "gno.land/r/gnoswap/v1/gns")
 } 

--- a/volos-tests/gov_test.mk
+++ b/volos-tests/gov_test.mk
@@ -1,6 +1,3 @@
-# Governance testing flow - Basic environment setup
-# This file sets up a real governance environment for testing
-
 include _info.mk
 include ../gnoswap-tests/test.mk
 

--- a/volos-tests/test.mk
+++ b/volos-tests/test.mk
@@ -35,34 +35,34 @@ market-create-bar-wugnot:
 # Test getting pool price for GNS-WUGNOT market
 market-get-price-gns-wugnot:
 	$(info ************ Test getting pool price for GNS-WUGNOT market ************)
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetMarketPrice(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetMarketPrice(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0\")"
 	@echo
 
 # Test getting market info for GNS-WUGNOT pair
 market-get-gns-wugnot:
 	$(info ************ Test getting market info for GNS-WUGNOT pair ************)
 	# GET TOTAL SUPPLY ASSETS
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetTotalSupplyAssets(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetTotalSupplyAssets(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0\")"
 	@echo
 
 	# GET TOTAL SUPPLY SHARES
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetTotalSupplyShares(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetTotalSupplyShares(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0\")"
 	@echo
 
 	# GET TOTAL BORROW ASSETS
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetTotalBorrowAssets(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetTotalBorrowAssets(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0\")"
 	@echo
 
 	# GET TOTAL BORROW SHARES
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetTotalBorrowShares(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetTotalBorrowShares(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0\")"
 	@echo
 
 	# GET LIQUIDATION LTV
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetLLTV(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetLLTV(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0\")"
 	@echo
 
 	# GET MARKET FEE
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetFee(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetFee(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0\")"
 	@echo
 
 # Test supplying assets to GNS-WUGNOT market
@@ -77,7 +77,7 @@ supply-assets-gns-wugnot:
 	@echo
 
 	# THEN SUPPLY
-	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Supply -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000" -args 1000000 -args 0 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
+	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Supply -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0" -args 1000000 -args 0 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
 	@echo
 
 # Test supplying shares to GNS-WUGNOT market
@@ -92,28 +92,28 @@ supply-shares-gns-wugnot:
 	@echo
 
 	# THEN SUPPLY
-	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Supply -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000" -args 0 -args 1000000 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
+	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Supply -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0" -args 0 -args 1000000 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
 	@echo
 
 # Test withdrawing assets from GNS-WUGNOT market
 withdraw-assets-gns-wugnot:
 	$(info ************ Test withdrawing GNS assets from GNS-WUGNOT market ************)
-	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Withdraw -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000" -args 994940 -args 0 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
+	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Withdraw -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0" -args 994940 -args 0 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
 	@echo
 
 # Check user position in GNS-WUGNOT market
 check-position-gns-wugnot:
 	$(info ************ Check user position in GNS-WUGNOT market ************)
 	# Check supply shares
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetPositionSupplyShares(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000\", \"$(ADMIN)\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetPositionSupplyShares(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0\", \"$(ADMIN)\")"
 	@echo
 
 	# Check borrow shares
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetPositionBorrowShares(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000\", \"$(ADMIN)\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetPositionBorrowShares(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0\", \"$(ADMIN)\")"
 	@echo
 
 	# Check collateral
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetPositionCollateral(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000\", \"$(ADMIN)\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetPositionCollateral(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0\", \"$(ADMIN)\")"
 	@echo
 
 # Check GNS balance
@@ -137,7 +137,7 @@ check-volos-wugnot-balance:
 # Test accruing interest on GNS-WUGNOT market
 accrue-interest-gns-wugnot:
 	$(info ************ Test accruing interest on GNS-WUGNOT market ************)
-	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func AccrueInterest -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000" -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
+	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func AccrueInterest -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0" -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
 	@echo
 
 # Check WUGNOT balance
@@ -155,7 +155,7 @@ wrap-ugnot:
 # Test borrowing GNS tokens
 borrow-gns:
 	$(info ************ Test borrowing GNS tokens ************)
-	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Borrow -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000" -args 740000 -args 0 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
+	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Borrow -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0" -args 740000 -args 0 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
 	@echo
 
 # Test repaying GNS tokens
@@ -166,7 +166,7 @@ repay-gns:
 	@echo
 
 	# THEN REPAY
-	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Repay -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000" -args 50 -args 0 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
+	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Repay -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0" -args 50 -args 0 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
 	@echo
 
 # Test liquidating GNS position
@@ -177,7 +177,7 @@ liquidate-gns:
 	@echo
 
 	# THEN LIQUIDATE
-	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Liquidate -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000" -args $(ADMIN) -args 0 -args 25 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
+	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Liquidate -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0" -args $(ADMIN) -args 0 -args 25 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
 	@echo
 
 # Test supplying collateral to GNS-WUGNOT market
@@ -188,13 +188,13 @@ supply-collateral-gns-wugnot:
 	@echo
 
 	# THEN SUPPLY COLLATERAL
-	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func SupplyCollateral -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000" -args 1000000 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
+	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func SupplyCollateral -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0" -args 1000000 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
 	@echo
 
 # Test withdrawing collateral from GNS-WUGNOT market
 withdraw-collateral-gns-wugnot:
 	$(info ************ Test withdrawing collateral from GNS-WUGNOT market ************)
-	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func WithdrawCollateral -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000" -args 500 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
+	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func WithdrawCollateral -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000:0" -args 500 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
 	@echo
 
 # Test supplying assets to BAR-WUGNOT market
@@ -209,7 +209,7 @@ supply-assets-bar-wugnot:
 	@echo
 
 	# THEN SUPPLY
-	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Supply -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000" -args 1000000 -args 0 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
+	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Supply -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000:0" -args 1000000 -args 0 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
 	@echo
 
 # Test supplying collateral to BAR-WUGNOT market
@@ -220,32 +220,32 @@ supply-collateral-bar-wugnot:
 	@echo
 
 	# THEN SUPPLY COLLATERAL
-	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func SupplyCollateral -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000" -args 1000000 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
+	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func SupplyCollateral -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000:0" -args 1000000 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
 	@echo
 
 # Test borrowing BAR tokens
 borrow-bar:
 	$(info ************ Test borrowing BAR tokens ************)
-	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Borrow -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000" -args 500000 -args 0 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
+	@echo "" | gnokey maketx call -pkgpath gno.land/r/volos/core -func Borrow -args "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000:0" -args 500000 -args 0 -insecure-password-stdin=true -remote $(GNOLAND_RPC_URL) -broadcast=true -chainid $(CHAINID) -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" gnoswap_admin
 	@echo
 
 # Check user position in BAR-WUGNOT market
 check-position-bar-wugnot:
 	$(info ************ Check user position in BAR-WUGNOT market ************)
 	# Check supply shares
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetPositionSupplyShares(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000\", \"$(ADMIN)\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetPositionSupplyShares(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000:0\", \"$(ADMIN)\")"
 	@echo
 
 	# Check borrow shares
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetPositionBorrowShares(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000\", \"$(ADMIN)\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetPositionBorrowShares(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000:0\", \"$(ADMIN)\")"
 	@echo
 
 	# Check collateral
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetPositionCollateral(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000\", \"$(ADMIN)\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetPositionCollateral(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000:0\", \"$(ADMIN)\")"
 	@echo
 
 	# Check health factor
-	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetHealthFactor(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000\", \"$(ADMIN)\")"
+	gnokey query vm/qeval -remote $(GNOLAND_RPC_URL) -data "gno.land/r/volos/core.GetHealthFactor(\"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/test_token/bar:3000:0\", \"$(ADMIN)\")"
 	@echo
 
 # Check volos owner


### PR DESCRIPTION
This PR enables creating two markets for the same pool with different token directions by adding directional suffixes to market IDs.