### PR TITLE
feat: lock vls until proposal expires & better delegation tracking

### DIFF
--- a/examples/gno.land/r/volos/gov/governance/api.gno
+++ b/examples/gno.land/r/volos/gov/governance/api.gno
@@ -1,9 +1,10 @@
 package governance
 
 import (
-	"gno.land/p/demo/json"
-	"strconv"
 	"std"
+	"strconv"
+
+	"gno.land/p/demo/json"
 )
 
 // ApiGetProposal returns a proposal as JSON string
@@ -12,12 +13,12 @@ func ApiGetProposal(proposalID string) string {
 	if err != nil {
 		return marshalError("invalid proposal ID")
 	}
-	
+
 	proposal := GetProposal(id)
 	if proposal == nil {
 		return marshalError("proposal not found")
 	}
-	
+
 	rpcProposal := ProposalToRpc(proposal)
 	return marshal(rpcProposal.JSON())
 }
@@ -53,7 +54,7 @@ func ApiGetUserInfo(userAddr string) string {
 	if !addr.IsValid() {
 		return marshalError("invalid address")
 	}
-	
+
 	userInfo := UserInfoToRpc(addr)
 	return marshal(userInfo.JSON())
 }

--- a/examples/gno.land/r/volos/gov/governance/api.gno
+++ b/examples/gno.land/r/volos/gov/governance/api.gno
@@ -58,6 +58,17 @@ func ApiGetUserInfo(userAddr string) string {
 	return marshal(userInfo.JSON())
 }
 
+// ApiGetUserActiveVotes returns all active proposals that the user has voted on
+func ApiGetUserActiveVotes(userAddr string) string {
+	addr := std.Address(userAddr)
+	if !addr.IsValid() {
+		return marshalError("invalid address")
+	}
+	list := GetUserActiveProposals(addr)
+	rpc := UserActiveVotesToRpc(addr, list)
+	return marshal(rpc.JSON())
+}
+
 func marshal(node *json.Node) string {
 	b, err := json.Marshal(node)
 	if err != nil {

--- a/examples/gno.land/r/volos/gov/governance/json.gno
+++ b/examples/gno.land/r/volos/gov/governance/json.gno
@@ -1,37 +1,38 @@
 package governance
 
 import (
+	"std"
+
 	"gno.land/p/demo/json"
 	"gno.land/p/nt/commondao"
 	"gno.land/r/volos/gov/vls"
 	"gno.land/r/volos/gov/xvls"
-	"std"
 )
 
 // RpcProposal represents a proposal in RPC format
 type RpcProposal struct {
-	ID              uint64 `json:"id"`
-	Title           string `json:"title"`
-	Body            string `json:"body"`
-	Status          string `json:"status"`
-	VotingDeadline  int64  `json:"votingDeadline"`
-	Proposer        string `json:"proposer"`
-	QuorumAtCreation int64 `json:"quorumAtCreation"`
+	ID               uint64 `json:"id"`
+	Title            string `json:"title"`
+	Body             string `json:"body"`
+	Status           string `json:"status"`
+	VotingDeadline   int64  `json:"votingDeadline"`
+	Proposer         string `json:"proposer"`
+	QuorumAtCreation int64  `json:"quorumAtCreation"`
 }
 
 func ProposalToRpc(proposal *commondao.Proposal) RpcProposal {
 	if proposal == nil {
 		return RpcProposal{}
 	}
-	
+
 	def := proposal.Definition().(VolosProposalDefinition)
 	return RpcProposal{
-		ID:              proposal.ID(),
-		Title:           def.Title(),
-		Body:            def.Body(),
-		Status:          string(proposal.Status()),
-		VotingDeadline:  proposal.VotingDeadline().Unix(),
-		Proposer:        proposal.Creator().String(),
+		ID:               proposal.ID(),
+		Title:            def.Title(),
+		Body:             def.Body(),
+		Status:           string(proposal.Status()),
+		VotingDeadline:   proposal.VotingDeadline().Unix(),
+		Proposer:         proposal.Creator().String(),
 		QuorumAtCreation: def.QuorumAtCreation,
 	}
 }
@@ -60,7 +61,7 @@ func MemberSetToRpc(memberSet commondao.MemberSet) RpcMemberSet {
 		members = append(members, addr.String())
 		return false
 	})
-	
+
 	return RpcMemberSet{
 		Members: members,
 		Size:    memberSet.Size(),
@@ -72,7 +73,7 @@ func (r RpcMemberSet) JSON() *json.Node {
 	for _, member := range r.Members {
 		memberNodes = append(memberNodes, json.StringNode("", member))
 	}
-	
+
 	return json.ObjectNode("memberSet", map[string]*json.Node{
 		"members": json.ArrayNode("members", memberNodes),
 		"size":    json.NumberNode("size", float64(r.Size)),
@@ -81,20 +82,20 @@ func (r RpcMemberSet) JSON() *json.Node {
 
 // RpcUserInfo represents user information in RPC format
 type RpcUserInfo struct {
-	Address          string `json:"address"`
-	VlsBalance       int64  `json:"vlsBalance"`
-	XvlsBalance      int64  `json:"xvlsBalance"`
-	ProposalThreshold int64 `json:"proposalThreshold"`
-	IsMember         bool   `json:"isMember"`
+	Address           string `json:"address"`
+	VlsBalance        int64  `json:"vlsBalance"`
+	XvlsBalance       int64  `json:"xvlsBalance"`
+	ProposalThreshold int64  `json:"proposalThreshold"`
+	IsMember          bool   `json:"isMember"`
 }
 
 func UserInfoToRpc(userAddr std.Address) RpcUserInfo {
 	return RpcUserInfo{
-		Address:          userAddr.String(),
-		VlsBalance:       vls.BalanceOf(userAddr),
-		XvlsBalance:      xvls.BalanceOf(userAddr),
+		Address:           userAddr.String(),
+		VlsBalance:        vls.BalanceOf(userAddr),
+		XvlsBalance:       xvls.BalanceOf(userAddr),
 		ProposalThreshold: ProposalThreshold(),
-		IsMember:         volosGovernance.Members().Has(userAddr),
+		IsMember:          volosGovernance.Members().Has(userAddr),
 	}
 }
 
@@ -110,8 +111,8 @@ func (r RpcUserInfo) JSON() *json.Node {
 
 // RpcUserActiveVotes lists active proposals a user voted on
 type RpcUserActiveVotes struct {
-	User      string          `json:"user"`
-	Proposals []RpcProposal   `json:"proposals"`
+	User      string        `json:"user"`
+	Proposals []RpcProposal `json:"proposals"`
 }
 
 func UserActiveVotesToRpc(user std.Address, proposals []*commondao.Proposal) RpcUserActiveVotes {

--- a/examples/gno.land/r/volos/gov/governance/json.gno
+++ b/examples/gno.land/r/volos/gov/governance/json.gno
@@ -107,3 +107,31 @@ func (r RpcUserInfo) JSON() *json.Node {
 		"isMember":          json.BoolNode("isMember", r.IsMember),
 	})
 }
+
+// RpcUserActiveVotes lists active proposals a user voted on
+type RpcUserActiveVotes struct {
+	User      string          `json:"user"`
+	Proposals []RpcProposal   `json:"proposals"`
+}
+
+func UserActiveVotesToRpc(user std.Address, proposals []*commondao.Proposal) RpcUserActiveVotes {
+	items := make([]RpcProposal, 0, len(proposals))
+	for _, p := range proposals {
+		items = append(items, ProposalToRpc(p))
+	}
+	return RpcUserActiveVotes{
+		User:      user.String(),
+		Proposals: items,
+	}
+}
+
+func (r RpcUserActiveVotes) JSON() *json.Node {
+	arr := []*json.Node{}
+	for _, p := range r.Proposals {
+		arr = append(arr, p.JSON())
+	}
+	return json.ObjectNode("userActiveVotes", map[string]*json.Node{
+		"user":      json.StringNode("user", r.User),
+		"proposals": json.ArrayNode("proposals", arr),
+	})
+}

--- a/examples/gno.land/r/volos/gov/governance/proposal.gno
+++ b/examples/gno.land/r/volos/gov/governance/proposal.gno
@@ -95,7 +95,7 @@ func CreateProposal(cur realm, title, body string, votingPeriod time.Duration, a
 		BodyField:         body,
 		VotingPeriodField: votingPeriod,
 		Action:            action,
-		QuorumAtCreation:  votingPowerQuorum, 
+		QuorumAtCreation:  votingPowerQuorum,
 	}
 
 	proposal := volosGovernance.MustPropose(proposer, def)

--- a/examples/gno.land/r/volos/gov/governance/proposal.gno
+++ b/examples/gno.land/r/volos/gov/governance/proposal.gno
@@ -120,3 +120,18 @@ func Execute(cur realm, proposalID uint64) {
 
 	emitProposalExecuted(caller, proposalID)
 }
+
+// GetUserActiveProposals returns all active proposals that the given user has voted on.
+// It iterates the active proposals and checks the voting record for the user.
+func GetUserActiveProposals(user std.Address) []*commondao.Proposal {
+	proposals := []*commondao.Proposal{}
+	active := volosGovernance.ActiveProposals()
+	count := active.Size()
+	active.Iterate(0, count, false, func(p *commondao.Proposal) bool {
+		if p != nil && p.VotingRecord().Readonly().HasVoted(user) {
+			proposals = append(proposals, p)
+		}
+		return false
+	})
+	return proposals
+}

--- a/examples/gno.land/r/volos/gov/staker/errors.gno
+++ b/examples/gno.land/r/volos/gov/staker/errors.gno
@@ -10,4 +10,5 @@ var (
 	ErrInsufficientAllowance = errors.New("insufficient allowance")
 	ErrInsufficientBalance   = errors.New("insufficient balance")
 	ErrCooldownNotFinished   = errors.New("cooldown not finished")
+	ErrInsufficientDelegation = errors.New("insufficient delegation")
 )

--- a/examples/gno.land/r/volos/gov/staker/errors.gno
+++ b/examples/gno.land/r/volos/gov/staker/errors.gno
@@ -5,10 +5,10 @@ import (
 )
 
 var (
-	ErrInvalidAmount         = errors.New("amount must be positive")
-	ErrInvalidDelegatee      = errors.New("invalid delegatee address")
-	ErrInsufficientAllowance = errors.New("insufficient allowance")
-	ErrInsufficientBalance   = errors.New("insufficient balance")
-	ErrCooldownNotFinished   = errors.New("cooldown not finished")
+	ErrInvalidAmount          = errors.New("amount must be positive")
+	ErrInvalidDelegatee       = errors.New("invalid delegatee address")
+	ErrInsufficientAllowance  = errors.New("insufficient allowance")
+	ErrInsufficientBalance    = errors.New("insufficient balance")
+	ErrCooldownNotFinished    = errors.New("cooldown not finished")
 	ErrInsufficientDelegation = errors.New("insufficient delegation")
 )

--- a/examples/gno.land/r/volos/gov/staker/events.gno
+++ b/examples/gno.land/r/volos/gov/staker/events.gno
@@ -39,7 +39,7 @@ func emitStake(caller, staker, delegatee std.Address, amount int64) {
 		EventStakerKey, staker.String(),
 		EventDelegateeKey, delegatee.String(),
 		EventAmountKey, strconv.FormatInt(amount, 10),
-		EventCooldownPeriodKey, strconv.FormatInt(UnstakeLockPeriod, 10),
+		EventCooldownPeriodKey, strconv.FormatInt(UnstakeLockPeriod(), 10),
 		EventTimestampKey, strconv.FormatInt(time.Now().Unix(), 10),
 	)
 }
@@ -53,7 +53,7 @@ func emitBeginUnstake(caller, staker, delegatee std.Address, amount int64, unloc
 		EventDelegateeKey, delegatee.String(),
 		EventAmountKey, strconv.FormatInt(amount, 10),
 		EventUnlockAtKey, strconv.FormatInt(unlockAt, 10),
-		EventCooldownPeriodKey, strconv.FormatInt(UnstakeLockPeriod, 10),
+		EventCooldownPeriodKey, strconv.FormatInt(UnstakeLockPeriod(), 10),
 		EventTimestampKey, strconv.FormatInt(time.Now().Unix(), 10),
 	)
 }

--- a/examples/gno.land/r/volos/gov/staker/events.gno
+++ b/examples/gno.land/r/volos/gov/staker/events.gno
@@ -15,20 +15,20 @@ const (
 )
 
 const (
-	EventStakerKey     = "staker"
-	EventDelegateeKey  = "delegatee"
-	EventAmountKey     = "amount"
-	EventUnlockAtKey   = "unlock_at"
-	EventMemberKey     = "member"
-	EventTotalWithdrawnKey = "total_withdrawn"
+	EventStakerKey            = "staker"
+	EventDelegateeKey         = "delegatee"
+	EventAmountKey            = "amount"
+	EventUnlockAtKey          = "unlock_at"
+	EventMemberKey            = "member"
+	EventTotalWithdrawnKey    = "total_withdrawn"
 	EventRemainingUnstakesKey = "remaining_unstakes"
-	EventCallerKey     = "caller"
-	EventTimestampKey  = "timestamp"
-	EventCooldownPeriodKey = "cooldown_period"
-	EventPendingUnstakesKey = "pending_unstakes"
-	EventVlsBalanceKey = "vls_balance"
-	EventXvlsBalanceKey = "xvls_balance"
-	EventUnstakeInfoKey = "unstake_info"
+	EventCallerKey            = "caller"
+	EventTimestampKey         = "timestamp"
+	EventCooldownPeriodKey    = "cooldown_period"
+	EventPendingUnstakesKey   = "pending_unstakes"
+	EventVlsBalanceKey        = "vls_balance"
+	EventXvlsBalanceKey       = "xvls_balance"
+	EventUnstakeInfoKey       = "unstake_info"
 )
 
 // emitStake emits an event when VLS tokens are staked
@@ -88,4 +88,4 @@ func emitMemberRemoved(caller, member std.Address) {
 		EventMemberKey, member.String(),
 		EventTimestampKey, strconv.FormatInt(time.Now().Unix(), 10),
 	)
-} 
+}

--- a/examples/gno.land/r/volos/gov/staker/staker.gno
+++ b/examples/gno.land/r/volos/gov/staker/staker.gno
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"gno.land/p/demo/avl"
+	"gno.land/p/demo/avl/rotree"
 	"gno.land/p/moul/authz"
 	"gno.land/r/volos/gov/governance"
 	"gno.land/r/volos/gov/vls"
@@ -37,6 +38,17 @@ var (
 
 func UnstakeLockPeriod() int64 {
 	return unstakeLockPeriod
+}
+
+// Delegations returns a read-only view of all delegations.
+// The tree structure is: staker address (string) -> *rotree.ReadOnlyTree(delegatee address (string) -> int64 amount)
+func Delegations() *rotree.ReadOnlyTree {
+	makeEntrySafeFn := func(v any) any {
+		delegationTree := v.(*avl.Tree)
+		return rotree.Wrap(delegationTree, nil)
+	}
+	
+	return rotree.Wrap(delegations, makeEntrySafeFn)
 }
 
 // Stake locks VLS tokens from the caller and mints an equal amount of xVLS to the specified delegatee.

--- a/examples/gno.land/r/volos/gov/staker/staker.gno
+++ b/examples/gno.land/r/volos/gov/staker/staker.gno
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"gno.land/p/demo/avl"
+	"gno.land/p/moul/authz"
 	"gno.land/r/volos/gov/governance"
 	"gno.land/r/volos/gov/vls"
 	"gno.land/r/volos/gov/xvls"
@@ -27,9 +28,16 @@ type UnstakeInfo struct {
 }
 
 var (
-	UnstakeLockPeriod = int64(7 * 24 * 60 * 60) // 7 days cooldown for unstaking
+	unstakeLockPeriod = int64(7 * 24 * 60 * 60) // 7 days cooldown for unstaking
 	pendingUnstakes   = avl.NewTree()           // staker address (string) -> []UnstakeInfo
+	delegations       = avl.NewTree()           // staker address (string) -> avl.Tree(delegatee address (string) -> int64 amount)
+	
+	authorizer = authz.NewWithMembers(std.DerivePkgAddr("gno.land/r/volos/gov/governance"))
 )
+
+func UnstakeLockPeriod() int64 {
+	return unstakeLockPeriod
+}
 
 // Stake locks VLS tokens from the caller and mints an equal amount of xVLS to the specified delegatee.
 // The delegatee can be the caller or any other address, allowing flexible delegation of voting power.
@@ -47,12 +55,16 @@ func Stake(cur realm, amount int64, delegatee std.Address) {
 	xvls.Mint(cross, delegatee, amount)
 	governance.AddMember(cross, delegatee)
 	
+	updateDelegation(caller, delegatee, amount)
+	
 	emitStake(caller, caller, delegatee, amount)
 	emitMemberAdded(caller, delegatee)
 }
 
 // BeginUnstake burns xVLS from the delegatee and starts a cooldown period for the original staker.
 // The staker can have multiple pending unstakes, each with its own amount and unlock time.
+// If the user has voted on active proposals, the unlock time is extended until the last proposal
+// expires plus the standard cooldown period to prevent vote-and-exit scenarios.
 // After the cooldown, the staker can withdraw the corresponding amount of VLS.
 func BeginUnstake(cur realm, amount int64, delegatee std.Address) {
 	caller := std.PreviousRealm().Address()
@@ -68,18 +80,28 @@ func BeginUnstake(cur realm, amount int64, delegatee std.Address) {
 		panic(ErrInsufficientBalance)
 	}
 
+	delegatedAmount := GetDelegatedAmount(caller, delegatee)
+	if delegatedAmount < amount {
+		panic(ErrInsufficientDelegation)
+	}
+
 	xvls.Burn(cross, delegatee, amount)
 	if xvls.BalanceOf(delegatee) == 0 {
 		governance.RemoveMember(cross, delegatee)
 		emitMemberRemoved(caller, delegatee)
 	}
+
+	updateDelegation(caller, delegatee, -amount)
+
 	key := caller.String()
 	var list []UnstakeInfo
 	if existing, ok := pendingUnstakes.Get(key); ok {
 		list = existing.([]UnstakeInfo)
 	}
 
-	unlockAt := time.Now().Unix() + UnstakeLockPeriod
+	baseUnlockAt := time.Now().Unix() + unstakeLockPeriod
+	unlockAt := calculateUnlockTime(delegatee, baseUnlockAt)
+	
 	list = append(list, UnstakeInfo{
 		Amount:    amount,
 		UnlockAt:  unlockAt,
@@ -131,3 +153,33 @@ func WithdrawUnstaked(cur realm) {
 	
 	emitWithdraw(caller, caller, totalToWithdraw, len(remaining))
 }
+
+// SetUnstakeLockPeriod allows governance to change the unstake lock period.
+func SetUnstakeLockPeriod(cur realm, newPeriod int64) {
+	if err := authorizer.DoByPrevious("set_unstake_lock_period", func() error {
+		unstakeLockPeriod = newPeriod
+		return nil
+	}); err != nil {
+		panic(err)
+	}
+}
+
+// GetDelegatedAmount returns how much a staker has delegated to a specific delegatee.
+func GetDelegatedAmount(staker, delegatee std.Address) int64 {
+	stakerKey := staker.String()
+	delegateeKey := delegatee.String()
+	
+	stakerDelegationsAny, ok := delegations.Get(stakerKey)
+	if !ok {
+		return 0
+	}
+	
+	stakerDelegations := stakerDelegationsAny.(*avl.Tree)
+	amountAny, ok := stakerDelegations.Get(delegateeKey)
+	if !ok {
+		return 0
+	}
+	
+	return amountAny.(int64)
+}
+

--- a/examples/gno.land/r/volos/gov/staker/staker.gno
+++ b/examples/gno.land/r/volos/gov/staker/staker.gno
@@ -31,7 +31,7 @@ var (
 	unstakeLockPeriod = int64(7 * 24 * 60 * 60) // 7 days cooldown for unstaking
 	pendingUnstakes   = avl.NewTree()           // staker address (string) -> []UnstakeInfo
 	delegations       = avl.NewTree()           // staker address (string) -> avl.Tree(delegatee address (string) -> int64 amount)
-	
+
 	authorizer = authz.NewWithMembers(std.DerivePkgAddr("gno.land/r/volos/gov/governance"))
 )
 
@@ -54,9 +54,9 @@ func Stake(cur realm, amount int64, delegatee std.Address) {
 	vls.TransferFrom(cross, caller, std.CurrentRealm().Address(), amount)
 	xvls.Mint(cross, delegatee, amount)
 	governance.AddMember(cross, delegatee)
-	
+
 	updateDelegation(caller, delegatee, amount)
-	
+
 	emitStake(caller, caller, delegatee, amount)
 	emitMemberAdded(caller, delegatee)
 }
@@ -101,7 +101,7 @@ func BeginUnstake(cur realm, amount int64, delegatee std.Address) {
 
 	baseUnlockAt := time.Now().Unix() + unstakeLockPeriod
 	unlockAt := calculateUnlockTime(delegatee, baseUnlockAt)
-	
+
 	list = append(list, UnstakeInfo{
 		Amount:    amount,
 		UnlockAt:  unlockAt,
@@ -109,7 +109,7 @@ func BeginUnstake(cur realm, amount int64, delegatee std.Address) {
 	})
 
 	pendingUnstakes.Set(key, list)
-	
+
 	emitBeginUnstake(caller, caller, delegatee, amount, unlockAt)
 }
 
@@ -150,7 +150,7 @@ func WithdrawUnstaked(cur realm) {
 	} else {
 		pendingUnstakes.Set(key, remaining)
 	}
-	
+
 	emitWithdraw(caller, caller, totalToWithdraw, len(remaining))
 }
 
@@ -168,18 +168,17 @@ func SetUnstakeLockPeriod(cur realm, newPeriod int64) {
 func GetDelegatedAmount(staker, delegatee std.Address) int64 {
 	stakerKey := staker.String()
 	delegateeKey := delegatee.String()
-	
+
 	stakerDelegationsAny, ok := delegations.Get(stakerKey)
 	if !ok {
 		return 0
 	}
-	
+
 	stakerDelegations := stakerDelegationsAny.(*avl.Tree)
 	amountAny, ok := stakerDelegations.Get(delegateeKey)
 	if !ok {
 		return 0
 	}
-	
+
 	return amountAny.(int64)
 }
-

--- a/examples/gno.land/r/volos/gov/staker/staker_test.gno
+++ b/examples/gno.land/r/volos/gov/staker/staker_test.gno
@@ -217,13 +217,13 @@ func TestDelegationMapping_BasicTracking(cur realm, t *testing.T) {
 	testing.SetRealm(std.NewUserRealm(alice))
 	crossThrough(std.NewUserRealm(alice), func() {
 		vls.Approve(cross, std.DerivePkgAddr("gno.land/r/volos/gov/staker"), 1000)
-		
+
 		Stake(cross, 600, alice)
 		urequire.Equal(t, int64(600), GetDelegatedAmount(alice, alice))
-		
+
 		Stake(cross, 200, bob)
 		urequire.Equal(t, int64(200), GetDelegatedAmount(alice, bob))
-		
+
 		Stake(cross, 200, charlie)
 		urequire.Equal(t, int64(200), GetDelegatedAmount(alice, charlie))
 	})
@@ -231,7 +231,7 @@ func TestDelegationMapping_BasicTracking(cur realm, t *testing.T) {
 	urequire.Equal(t, int64(600), GetDelegatedAmount(alice, alice))
 	urequire.Equal(t, int64(200), GetDelegatedAmount(alice, bob))
 	urequire.Equal(t, int64(200), GetDelegatedAmount(alice, charlie))
-	
+
 	urequire.Equal(t, int64(0), GetDelegatedAmount(bob, alice))
 	urequire.Equal(t, int64(0), GetDelegatedAmount(charlie, alice))
 }
@@ -300,14 +300,14 @@ func TestDelegationMapping_MultipleStakersToSameDelegatee(cur realm, t *testing.
 		vls.Approve(cross, std.DerivePkgAddr("gno.land/r/volos/gov/staker"), 1000)
 		Stake(cross, 600, charlie)
 	})
-	
+
 	crossThrough(std.NewUserRealm(bob), func() {
 		vls.Approve(cross, std.DerivePkgAddr("gno.land/r/volos/gov/staker"), 1000)
 		Stake(cross, 400, charlie)
 	})
 
 	urequire.Equal(t, int64(1000), xvls.BalanceOf(charlie))
-	
+
 	urequire.Equal(t, int64(600), GetDelegatedAmount(alice, charlie))
 	urequire.Equal(t, int64(400), GetDelegatedAmount(bob, charlie))
 	urequire.Equal(t, int64(0), GetDelegatedAmount(charlie, charlie))
@@ -315,7 +315,7 @@ func TestDelegationMapping_MultipleStakersToSameDelegatee(cur realm, t *testing.
 	crossThrough(std.NewUserRealm(alice), func() {
 		BeginUnstake(cross, 300, charlie)
 	})
-	
+
 	urequire.Equal(t, int64(700), xvls.BalanceOf(charlie))
 	urequire.Equal(t, int64(300), GetDelegatedAmount(alice, charlie))
 	urequire.Equal(t, int64(400), GetDelegatedAmount(bob, charlie))
@@ -343,14 +343,14 @@ func TestDelegationMapping_CompleteUnstakeAndRedelegate(cur realm, t *testing.T)
 
 	crossThrough(std.NewUserRealm(alice), func() {
 		vls.Approve(cross, std.DerivePkgAddr("gno.land/r/volos/gov/staker"), 1000)
-		
+
 		Stake(cross, 500, bob)
 		urequire.Equal(t, int64(500), GetDelegatedAmount(alice, bob))
-		
+
 		BeginUnstake(cross, 500, bob)
 		urequire.Equal(t, int64(0), GetDelegatedAmount(alice, bob))
 		urequire.Equal(t, int64(0), xvls.BalanceOf(bob))
-		
+
 		Stake(cross, 300, bob)
 		urequire.Equal(t, int64(300), GetDelegatedAmount(alice, bob))
 		urequire.Equal(t, int64(300), xvls.BalanceOf(bob))
@@ -359,24 +359,24 @@ func TestDelegationMapping_CompleteUnstakeAndRedelegate(cur realm, t *testing.T)
 
 func TestUnstakeLockPeriod_GetterAndSetter(cur realm, t *testing.T) {
 	gov := "gno.land/r/volos/gov/governance"
-	
+
 	urequire.Equal(t, int64(7*24*60*60), UnstakeLockPeriod())
-	
+
 	crossThrough(std.NewCodeRealm(gov), func() {
-		SetUnstakeLockPeriod(cross, 14 * 24 * 60 * 60)
+		SetUnstakeLockPeriod(cross, 14*24*60*60)
 	})
 	urequire.Equal(t, int64(14*24*60*60), UnstakeLockPeriod())
-	
+
 	alice := std.DerivePkgAddr("alice_unauthorized")
 	crossThrough(std.NewUserRealm(alice), func() {
 		uassert.AbortsWithMessage(t, "unauthorized", func() {
-			SetUnstakeLockPeriod(cross, 1 * 24 * 60 * 60)
+			SetUnstakeLockPeriod(cross, 1*24*60*60)
 		})
 	})
 	urequire.Equal(t, int64(14*24*60*60), UnstakeLockPeriod())
-	
+
 	crossThrough(std.NewCodeRealm(gov), func() {
-		SetUnstakeLockPeriod(cross, 7 * 24 * 60 * 60)
+		SetUnstakeLockPeriod(cross, 7*24*60*60)
 	})
 	urequire.Equal(t, int64(7*24*60*60), UnstakeLockPeriod())
 }

--- a/examples/gno.land/r/volos/gov/staker/staker_test.gno
+++ b/examples/gno.land/r/volos/gov/staker/staker_test.gno
@@ -205,3 +205,178 @@ func TestStaker_GovernanceMembershipIntegration(cur realm, t *testing.T) {
 	})
 	urequire.True(t, governance.MemberSet().Has(alice))
 }
+
+func TestDelegationMapping_BasicTracking(cur realm, t *testing.T) {
+	alice := std.DerivePkgAddr("alice_delegation")
+	bob := std.DerivePkgAddr("bob_delegation")
+	charlie := std.DerivePkgAddr("charlie_delegation")
+
+	testing.SetRealm(std.NewCodeRealm(vls.VolosDAO))
+	vls.Mint(cross, vls.VolosDAOAddress, alice, 1000)
+
+	testing.SetRealm(std.NewUserRealm(alice))
+	crossThrough(std.NewUserRealm(alice), func() {
+		vls.Approve(cross, std.DerivePkgAddr("gno.land/r/volos/gov/staker"), 1000)
+		
+		Stake(cross, 600, alice)
+		urequire.Equal(t, int64(600), GetDelegatedAmount(alice, alice))
+		
+		Stake(cross, 200, bob)
+		urequire.Equal(t, int64(200), GetDelegatedAmount(alice, bob))
+		
+		Stake(cross, 200, charlie)
+		urequire.Equal(t, int64(200), GetDelegatedAmount(alice, charlie))
+	})
+
+	urequire.Equal(t, int64(600), GetDelegatedAmount(alice, alice))
+	urequire.Equal(t, int64(200), GetDelegatedAmount(alice, bob))
+	urequire.Equal(t, int64(200), GetDelegatedAmount(alice, charlie))
+	
+	urequire.Equal(t, int64(0), GetDelegatedAmount(bob, alice))
+	urequire.Equal(t, int64(0), GetDelegatedAmount(charlie, alice))
+}
+
+func TestDelegationMapping_UnstakeSecurity(cur realm, t *testing.T) {
+	alice := std.DerivePkgAddr("alice_security")
+	bob := std.DerivePkgAddr("bob_security")
+	charlie := std.DerivePkgAddr("charlie_security")
+
+	testing.SetRealm(std.NewCodeRealm(vls.VolosDAO))
+	vls.Mint(cross, vls.VolosDAOAddress, alice, 1000)
+	vls.Mint(cross, vls.VolosDAOAddress, bob, 1000)
+
+	crossThrough(std.NewUserRealm(alice), func() {
+		vls.Approve(cross, std.DerivePkgAddr("gno.land/r/volos/gov/staker"), 1000)
+		Stake(cross, 500, bob)
+	})
+
+	urequire.Equal(t, int64(500), xvls.BalanceOf(bob))
+	urequire.Equal(t, int64(500), GetDelegatedAmount(alice, bob))
+
+	crossThrough(std.NewUserRealm(bob), func() {
+		vls.Approve(cross, std.DerivePkgAddr("gno.land/r/volos/gov/staker"), 1000)
+		Stake(cross, 300, bob)
+	})
+
+	urequire.Equal(t, int64(800), xvls.BalanceOf(bob))
+	urequire.Equal(t, int64(300), GetDelegatedAmount(bob, bob))
+
+	crossThrough(std.NewUserRealm(alice), func() {
+		BeginUnstake(cross, 200, bob)
+	})
+
+	urequire.Equal(t, int64(600), xvls.BalanceOf(bob))
+	urequire.Equal(t, int64(300), GetDelegatedAmount(alice, bob))
+
+	crossThrough(std.NewUserRealm(bob), func() {
+		uassert.AbortsWithMessage(t, "insufficient delegation", func() {
+			BeginUnstake(cross, 400, bob)
+		})
+	})
+
+	crossThrough(std.NewUserRealm(charlie), func() {
+		uassert.AbortsWithMessage(t, "insufficient delegation", func() {
+			BeginUnstake(cross, 100, bob)
+		})
+	})
+
+	crossThrough(std.NewUserRealm(alice), func() {
+		uassert.AbortsWithMessage(t, "insufficient delegation", func() {
+			BeginUnstake(cross, 400, bob)
+		})
+	})
+}
+
+func TestDelegationMapping_MultipleStakersToSameDelegatee(cur realm, t *testing.T) {
+	alice := std.DerivePkgAddr("alice_multi")
+	bob := std.DerivePkgAddr("bob_multi")
+	charlie := std.DerivePkgAddr("charlie_multi")
+
+	testing.SetRealm(std.NewCodeRealm(vls.VolosDAO))
+	vls.Mint(cross, vls.VolosDAOAddress, alice, 1000)
+	vls.Mint(cross, vls.VolosDAOAddress, bob, 1000)
+
+	crossThrough(std.NewUserRealm(alice), func() {
+		vls.Approve(cross, std.DerivePkgAddr("gno.land/r/volos/gov/staker"), 1000)
+		Stake(cross, 600, charlie)
+	})
+	
+	crossThrough(std.NewUserRealm(bob), func() {
+		vls.Approve(cross, std.DerivePkgAddr("gno.land/r/volos/gov/staker"), 1000)
+		Stake(cross, 400, charlie)
+	})
+
+	urequire.Equal(t, int64(1000), xvls.BalanceOf(charlie))
+	
+	urequire.Equal(t, int64(600), GetDelegatedAmount(alice, charlie))
+	urequire.Equal(t, int64(400), GetDelegatedAmount(bob, charlie))
+	urequire.Equal(t, int64(0), GetDelegatedAmount(charlie, charlie))
+
+	crossThrough(std.NewUserRealm(alice), func() {
+		BeginUnstake(cross, 300, charlie)
+	})
+	
+	urequire.Equal(t, int64(700), xvls.BalanceOf(charlie))
+	urequire.Equal(t, int64(300), GetDelegatedAmount(alice, charlie))
+	urequire.Equal(t, int64(400), GetDelegatedAmount(bob, charlie))
+
+	crossThrough(std.NewUserRealm(bob), func() {
+		uassert.AbortsWithMessage(t, "insufficient delegation", func() {
+			BeginUnstake(cross, 500, charlie)
+		})
+	})
+
+	crossThrough(std.NewUserRealm(bob), func() {
+		BeginUnstake(cross, 400, charlie)
+	})
+	urequire.Equal(t, int64(300), xvls.BalanceOf(charlie))
+	urequire.Equal(t, int64(300), GetDelegatedAmount(alice, charlie))
+	urequire.Equal(t, int64(0), GetDelegatedAmount(bob, charlie))
+}
+
+func TestDelegationMapping_CompleteUnstakeAndRedelegate(cur realm, t *testing.T) {
+	alice := std.DerivePkgAddr("alice_complete")
+	bob := std.DerivePkgAddr("bob_complete")
+
+	testing.SetRealm(std.NewCodeRealm(vls.VolosDAO))
+	vls.Mint(cross, vls.VolosDAOAddress, alice, 1000)
+
+	crossThrough(std.NewUserRealm(alice), func() {
+		vls.Approve(cross, std.DerivePkgAddr("gno.land/r/volos/gov/staker"), 1000)
+		
+		Stake(cross, 500, bob)
+		urequire.Equal(t, int64(500), GetDelegatedAmount(alice, bob))
+		
+		BeginUnstake(cross, 500, bob)
+		urequire.Equal(t, int64(0), GetDelegatedAmount(alice, bob))
+		urequire.Equal(t, int64(0), xvls.BalanceOf(bob))
+		
+		Stake(cross, 300, bob)
+		urequire.Equal(t, int64(300), GetDelegatedAmount(alice, bob))
+		urequire.Equal(t, int64(300), xvls.BalanceOf(bob))
+	})
+}
+
+func TestUnstakeLockPeriod_GetterAndSetter(cur realm, t *testing.T) {
+	gov := "gno.land/r/volos/gov/governance"
+	
+	urequire.Equal(t, int64(7*24*60*60), UnstakeLockPeriod())
+	
+	crossThrough(std.NewCodeRealm(gov), func() {
+		SetUnstakeLockPeriod(cross, 14 * 24 * 60 * 60)
+	})
+	urequire.Equal(t, int64(14*24*60*60), UnstakeLockPeriod())
+	
+	alice := std.DerivePkgAddr("alice_unauthorized")
+	crossThrough(std.NewUserRealm(alice), func() {
+		uassert.AbortsWithMessage(t, "unauthorized", func() {
+			SetUnstakeLockPeriod(cross, 1 * 24 * 60 * 60)
+		})
+	})
+	urequire.Equal(t, int64(14*24*60*60), UnstakeLockPeriod())
+	
+	crossThrough(std.NewCodeRealm(gov), func() {
+		SetUnstakeLockPeriod(cross, 7 * 24 * 60 * 60)
+	})
+	urequire.Equal(t, int64(7*24*60*60), UnstakeLockPeriod())
+}

--- a/examples/gno.land/r/volos/gov/staker/utils.gno
+++ b/examples/gno.land/r/volos/gov/staker/utils.gno
@@ -1,0 +1,67 @@
+package staker
+
+import(
+	"std"
+	"gno.land/p/demo/avl"
+	"gno.land/r/volos/gov/governance"
+)
+
+
+// calculateUnlockTime determines the actual unlock time based on active proposals the user has voted on.
+// If the user has voted on active proposals, the unlock time is extended until the latest proposal
+// deadline plus the standard cooldown period.
+func calculateUnlockTime(delegatee std.Address, baseUnlockAt int64) int64 {
+	activeProposals := governance.GetUserActiveProposals(delegatee)
+		if len(activeProposals) == 0 {
+		return baseUnlockAt
+	}
+	
+	var latestDeadline int64 = 0
+	for _, proposal := range activeProposals {
+		deadline := proposal.VotingDeadline().Unix()
+		if deadline > latestDeadline {
+			latestDeadline = deadline
+		}
+	}
+	
+	extendedUnlockAt := latestDeadline + unstakeLockPeriod
+	
+	if extendedUnlockAt > baseUnlockAt {
+		return extendedUnlockAt
+	}
+
+	return baseUnlockAt
+}
+
+// updateDelegation updates the delegation mapping for a staker -> delegatee relationship.
+// Positive amount increases delegation, negative amount decreases delegation.
+func updateDelegation(staker, delegatee std.Address, amount int64) {
+	stakerKey := staker.String()
+	delegateeKey := delegatee.String()
+	
+	var stakerDelegations *avl.Tree
+	if existing, ok := delegations.Get(stakerKey); ok {
+		stakerDelegations = existing.(*avl.Tree)
+	} else {
+		stakerDelegations = avl.NewTree()
+	}
+	
+	currentAmount := int64(0)
+	if existing, ok := stakerDelegations.Get(delegateeKey); ok {
+		currentAmount = existing.(int64)
+	}
+	
+	newAmount := currentAmount + amount
+	if newAmount <= 0 {
+		stakerDelegations.Remove(delegateeKey)
+		if stakerDelegations.Size() == 0 {
+			delegations.Remove(stakerKey)
+		} else {
+			delegations.Set(stakerKey, stakerDelegations)
+		}
+
+	} else {
+		stakerDelegations.Set(delegateeKey, newAmount)
+		delegations.Set(stakerKey, stakerDelegations)
+	}
+}

--- a/examples/gno.land/r/volos/gov/staker/utils.gno
+++ b/examples/gno.land/r/volos/gov/staker/utils.gno
@@ -1,21 +1,21 @@
 package staker
 
-import(
+import (
 	"std"
+
 	"gno.land/p/demo/avl"
 	"gno.land/r/volos/gov/governance"
 )
-
 
 // calculateUnlockTime determines the actual unlock time based on active proposals the user has voted on.
 // If the user has voted on active proposals, the unlock time is extended until the latest proposal
 // deadline plus the standard cooldown period.
 func calculateUnlockTime(delegatee std.Address, baseUnlockAt int64) int64 {
 	activeProposals := governance.GetUserActiveProposals(delegatee)
-		if len(activeProposals) == 0 {
+	if len(activeProposals) == 0 {
 		return baseUnlockAt
 	}
-	
+
 	var latestDeadline int64 = 0
 	for _, proposal := range activeProposals {
 		deadline := proposal.VotingDeadline().Unix()
@@ -23,9 +23,9 @@ func calculateUnlockTime(delegatee std.Address, baseUnlockAt int64) int64 {
 			latestDeadline = deadline
 		}
 	}
-	
+
 	extendedUnlockAt := latestDeadline + unstakeLockPeriod
-	
+
 	if extendedUnlockAt > baseUnlockAt {
 		return extendedUnlockAt
 	}
@@ -38,19 +38,19 @@ func calculateUnlockTime(delegatee std.Address, baseUnlockAt int64) int64 {
 func updateDelegation(staker, delegatee std.Address, amount int64) {
 	stakerKey := staker.String()
 	delegateeKey := delegatee.String()
-	
+
 	var stakerDelegations *avl.Tree
 	if existing, ok := delegations.Get(stakerKey); ok {
 		stakerDelegations = existing.(*avl.Tree)
 	} else {
 		stakerDelegations = avl.NewTree()
 	}
-	
+
 	currentAmount := int64(0)
 	if existing, ok := stakerDelegations.Get(delegateeKey); ok {
 		currentAmount = existing.(int64)
 	}
-	
+
 	newAmount := currentAmount + amount
 	if newAmount <= 0 {
 		stakerDelegations.Remove(delegateeKey)

--- a/examples/gno.land/r/volos/gov/vls/api.gno
+++ b/examples/gno.land/r/volos/gov/vls/api.gno
@@ -1,8 +1,9 @@
 package vls
 
 import (
-	"gno.land/p/demo/json"
 	"std"
+
+	"gno.land/p/demo/json"
 )
 
 // ApiGetTokenInfo returns VLS token information as JSON string
@@ -17,7 +18,7 @@ func ApiGetBalance(address string) string {
 	if !addr.IsValid() {
 		return marshalError("invalid address")
 	}
-	
+
 	balance := BalanceToRpc(addr)
 	return marshal(balance.JSON())
 }
@@ -26,14 +27,14 @@ func ApiGetBalance(address string) string {
 func ApiGetAllowance(owner, spender string) string {
 	ownerAddr := std.Address(owner)
 	spenderAddr := std.Address(spender)
-	
+
 	if !ownerAddr.IsValid() {
 		return marshalError("invalid owner address")
 	}
 	if !spenderAddr.IsValid() {
 		return marshalError("invalid spender address")
 	}
-	
+
 	allowance := AllowanceToRpc(ownerAddr, spenderAddr)
 	return marshal(allowance.JSON())
 }

--- a/examples/gno.land/r/volos/gov/vls/events.gno
+++ b/examples/gno.land/r/volos/gov/vls/events.gno
@@ -15,18 +15,18 @@ const (
 )
 
 const (
-	EventFromKey      = "from"
-	EventToKey        = "to"
-	EventAmountKey    = "amount"
-	EventOwnerKey     = "owner"
-	EventSpenderKey   = "spender"
-	EventValueKey     = "value"
-	EventOldPkgPathKey = "old_pkg_path"
-	EventNewPkgPathKey = "new_pkg_path"
-	EventCallerKey    = "caller"
-	EventTimestampKey = "timestamp"
+	EventFromKey        = "from"
+	EventToKey          = "to"
+	EventAmountKey      = "amount"
+	EventOwnerKey       = "owner"
+	EventSpenderKey     = "spender"
+	EventValueKey       = "value"
+	EventOldPkgPathKey  = "old_pkg_path"
+	EventNewPkgPathKey  = "new_pkg_path"
+	EventCallerKey      = "caller"
+	EventTimestampKey   = "timestamp"
 	EventTotalSupplyKey = "total_supply"
-	EventBalanceKey   = "balance"
+	EventBalanceKey     = "balance"
 )
 
 // emitMint emits an event when VLS tokens are minted

--- a/examples/gno.land/r/volos/gov/vls/json.gno
+++ b/examples/gno.land/r/volos/gov/vls/json.gno
@@ -1,8 +1,9 @@
 package vls
 
 import (
-	"gno.land/p/demo/json"
 	"std"
+
+	"gno.land/p/demo/json"
 )
 
 // RpcTokenInfo represents VLS token information in RPC format
@@ -53,9 +54,9 @@ func (r RpcBalance) JSON() *json.Node {
 
 // RpcAllowance represents an allowance in RPC format
 type RpcAllowance struct {
-	Owner    string `json:"owner"`
-	Spender  string `json:"spender"`
-	Allowance int64 `json:"allowance"`
+	Owner     string `json:"owner"`
+	Spender   string `json:"spender"`
+	Allowance int64  `json:"allowance"`
 }
 
 func AllowanceToRpc(owner, spender std.Address) RpcAllowance {

--- a/examples/gno.land/r/volos/gov/xvls/api.gno
+++ b/examples/gno.land/r/volos/gov/xvls/api.gno
@@ -1,8 +1,9 @@
 package xvls
 
 import (
-	"gno.land/p/demo/json"
 	"std"
+
+	"gno.land/p/demo/json"
 )
 
 // ApiGetTokenInfo returns xVLS token information as JSON string
@@ -17,7 +18,7 @@ func ApiGetBalance(address string) string {
 	if !addr.IsValid() {
 		return marshalError("invalid address")
 	}
-	
+
 	balance := BalanceToRpc(addr)
 	return marshal(balance.JSON())
 }

--- a/examples/gno.land/r/volos/gov/xvls/events.gno
+++ b/examples/gno.land/r/volos/gov/xvls/events.gno
@@ -13,16 +13,16 @@ const (
 )
 
 const (
-	EventToKey        = "to"
-	EventFromKey      = "from"
-	EventAmountKey    = "amount"
-	EventTotalSupplyKey = "total_supply"
+	EventToKey           = "to"
+	EventFromKey         = "from"
+	EventAmountKey       = "amount"
+	EventTotalSupplyKey  = "total_supply"
 	EventVotingSupplyKey = "voting_supply"
-	EventExcludedKey  = "excluded_balance"
-	EventCallerKey    = "caller"
-	EventTimestampKey = "timestamp"
-	EventBalanceKey   = "balance"
-	EventLaunchpadKey = "launchpad_address"
+	EventExcludedKey     = "excluded_balance"
+	EventCallerKey       = "caller"
+	EventTimestampKey    = "timestamp"
+	EventBalanceKey      = "balance"
+	EventLaunchpadKey    = "launchpad_address"
 )
 
 // emitMint emits an event when xVLS tokens are minted
@@ -63,4 +63,4 @@ func emitVotingSupply(caller std.Address, totalSupply, votingSupply int64, exclu
 		EventLaunchpadKey, Launchpad.String(),
 		EventTimestampKey, strconv.FormatInt(time.Now().Unix(), 10),
 	)
-} 
+}

--- a/examples/gno.land/r/volos/gov/xvls/json.gno
+++ b/examples/gno.land/r/volos/gov/xvls/json.gno
@@ -1,8 +1,9 @@
 package xvls
 
 import (
-	"gno.land/p/demo/json"
 	"std"
+
+	"gno.land/p/demo/json"
 )
 
 // RpcTokenInfo represents xVLS token information in RPC format

--- a/examples/gno.land/r/volos/gov/xvls/xvls.gno
+++ b/examples/gno.land/r/volos/gov/xvls/xvls.gno
@@ -92,7 +92,7 @@ func Burn(cur realm, from std.Address, amount int64) {
 	}); err != nil {
 		panic(err)
 	}
-	
+
 	caller := std.PreviousRealm().Address()
 	emitBurn(caller, from, amount)
 }

--- a/volos-tests/gov_test.mk
+++ b/volos-tests/gov_test.mk
@@ -5,6 +5,10 @@ include ../gnoswap-tests/test.mk
 gov-test-flow: faucet-vls approve-vls-for-staking stake-vls faucet-all-voters approve-all-voters stake-all-voters create-test-proposal vote-all-on-all-proposals
 	@echo "************ GOVERNANCE ENVIRONMENT SETUP COMPLETE ************"
 
+# Basic governance setup and test
+gov-test-flow-no-voting: faucet-vls approve-vls-for-staking stake-vls faucet-all-voters approve-all-voters stake-all-voters create-test-proposal
+	@echo "************ GOVERNANCE ENVIRONMENT SETUP COMPLETE ************"
+
 # Faucet VLS tokens
 faucet-vls:
 	$(info ************ Faucet VLS tokens ************)


### PR DESCRIPTION
- adds a func to governance that returns all active proposals user has voted on
- when user wants to begin unstake, on top of the existing unstake period, time until the last proposal that user has voted on expires gets added on the unstake period
- unstake period is no longer exported, and is now only changeable by governance through a setter (getter is also available)
- add delegation tracking through avl tree
- add helper function to update delegation tree on stake/unstake
