### PR TITLE
chore: add missing events attrs

### DIFF
--- a/examples/gno.land/r/volos/core/events.gno
+++ b/examples/gno.land/r/volos/core/events.gno
@@ -82,10 +82,12 @@ const (
 	EventCollateralTokenNameKey     = "collateralTokenName"
 	EventCollateralTokenSymbolKey   = "collateralTokenSymbol"
 	EventCollateralTokenDecimalsKey = "collateralTokenDecimals"
+	EventLLTVKey                    = "lltv"
 )
 
 // Event emission helper functions
 func emitCreateMarket(marketId string, loanToken string, collateralToken string) {
+	market, params := GetMarket(marketId)
 	var loanTokenName, loanTokenSymbol string
 	var loanTokenDecimals uint
 	var collateralTokenName, collateralTokenSymbol string
@@ -116,6 +118,7 @@ func emitCreateMarket(marketId string, loanToken string, collateralToken string)
 		EventCollateralTokenNameKey, collateralTokenName,
 		EventCollateralTokenSymbolKey, collateralTokenSymbol,
 		EventCollateralTokenDecimalsKey, strconv.FormatUint(uint64(collateralTokenDecimals), 10),
+		EventLLTVKey, params.LLTV.ToString(),
 		EventTimestampKey, strconv.FormatInt(time.Now().Unix(), 10),
 	)
 }

--- a/examples/gno.land/r/volos/core/events.gno
+++ b/examples/gno.land/r/volos/core/events.gno
@@ -87,7 +87,7 @@ const (
 
 // Event emission helper functions
 func emitCreateMarket(marketId string, loanToken string, collateralToken string) {
-	market, params := GetMarket(marketId)
+	_, params := GetMarket(marketId)
 	var loanTokenName, loanTokenSymbol string
 	var loanTokenDecimals uint
 	var collateralTokenName, collateralTokenSymbol string

--- a/examples/gno.land/r/volos/core/volos.gno
+++ b/examples/gno.land/r/volos/core/volos.gno
@@ -119,7 +119,7 @@ func SetFeeRecipient(cur realm, newFeeRecipient std.Address) {
 }
 
 // setFee sets the fee for a specific market
-func setFee(cur realm, marketId string, newFee *u256.Uint) {
+func SetFee(cur realm, marketId string, newFee *u256.Uint) {
 	Ownable.AssertOwnedByPrevious()
 
 	// Get market (will panic if not found)


### PR DESCRIPTION
STEFAN'S CHECKLIST

- [x] Add LLTV attr to create market event
- [x] In case Supply, Borrow, Withdraw or Repay functions are called with arg `assets = 0` and `shares > 0` convert the shares amount to assets amount and always emit assets in the events (this means shares attr can be removed from the event emitted)